### PR TITLE
refactor(UserSeed): remove unused import

### DIFF
--- a/SMIS.Infrastructure/DatabaseSeeders/UserSeed.cs
+++ b/SMIS.Infrastructure/DatabaseSeeders/UserSeed.cs
@@ -1,6 +1,5 @@
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
-using SMIS.Application.Common.Contants;
 using SMIS.Domain.Entities.Identity.Entity;
 
 namespace SMIS.Infrastructure.DatabaseSeeders;


### PR DESCRIPTION
Removed unused SMIS.Application.Common.Contants import from UserSeed.cs to clean up the code and remove unnecessary dependency.