### PR TITLE
fix(ProductGetListQuery): correct condition for empty product list check

### DIFF
--- a/SMIS.Application/Features/Products/Queries/ProductGetListQuery.cs
+++ b/SMIS.Application/Features/Products/Queries/ProductGetListQuery.cs
@@ -34,7 +34,7 @@ namespace SMIS.Application.Features.Products.Queries
             var query = _productRepository.GetAllQueryable(includeProperties: request.IncludeCategory ? "Category" : null);
             var products = await query.ToPagedList(request.PageNumber, request.PageSize);
 
-            if (!products.Items.Any())
+            if (products.Items.Any())
             {
                 return Result<PagedList<ProductDto>>.EmptyResult(nameof(ProductDto));
             }


### PR DESCRIPTION
This PR fixes the condition that checks for empty product list in the ProductGetListQuery to properly return an empty result when there are no products.\n\nChanges:\n- Changed condition from !products.Items.Any() to products.Items.Any()\n- This ensures proper handling of empty product lists