### PR TITLE
feat(LoanAccount): add name properties and repository dependencies

### DIFF
--- a/SMIS.Application/DTO/LoanAccounts/LoanAccountDto.cs
+++ b/SMIS.Application/DTO/LoanAccounts/LoanAccountDto.cs
@@ -7,10 +7,14 @@ public class LoanAccountDto
 {
     public string Id { get; set; } = string.Empty;
     public string CustomerId { get; set; } = string.Empty;
+    public string? CustomerName { get; set; }
     public string ShopId { get; set; } = string.Empty;
+    public string? ShopName { get; set; }
     public string ProductId { get; set; } = string.Empty;
+    public string? ProductName { get; set; }
     public decimal Quantity { get; set; }
     public string UnitId { get; set; } = string.Empty;
+    public string? UnitName { get; set; }
     public decimal PriceAtLoanTime { get; set; }
     public long TotalAmount { get; set; }
     public DateTime LoanDate { get; set; }

--- a/SMIS.Application/Features/LoanAccounts/Commands/LoanAccountCreateCommand.cs
+++ b/SMIS.Application/Features/LoanAccounts/Commands/LoanAccountCreateCommand.cs
@@ -3,7 +3,11 @@ using MediatR;
 using SMIS.Application.Common.Response;
 using SMIS.Application.DTO.LoanAccounts;
 using SMIS.Application.Repositories.Base;
+using SMIS.Application.Repositories.Customers;
 using SMIS.Application.Repositories.LoanAccounts;
+using SMIS.Application.Repositories.Products;
+using SMIS.Application.Repositories.Shops;
+using SMIS.Application.Repositories.UnitOfMeasures;
 using SMIS.Domain.Entities;
 
 namespace SMIS.Application.Features.LoanAccounts.Commands;
@@ -13,19 +17,39 @@ public record LoanAccountCreateCommand(LoanAccountCreateDto LoanAccountCreateDto
 internal sealed class LoanAccountCreateCommandHandler : IRequestHandler<LoanAccountCreateCommand, Result<LoanAccountDto>>
 {
     private readonly ILoanAccountRepository _loanAccountRepository;
+    private readonly ICustomerRepository _customerRepository;
+    private readonly IShopRepository _shopRepository;
+    private readonly IProductRepository _productRepository;
+    private readonly IUnitOfMeasureRepository _unitOfMeasureRepository;
     private readonly IUnitOfWork _unitOfWork;
     private readonly IMapper _mapper;
 
-    public LoanAccountCreateCommandHandler(IUnitOfWork unitOfWork, IMapper mapper, ILoanAccountRepository loanAccountRepository)
+    public LoanAccountCreateCommandHandler(IUnitOfWork unitOfWork, IMapper mapper, ILoanAccountRepository loanAccountRepository, ICustomerRepository customerRepository, IShopRepository shopRepository, IProductRepository productRepository, IUnitOfMeasureRepository unitOfMeasureRepository)
     {
         _unitOfWork = unitOfWork;
         _mapper = mapper;
         _loanAccountRepository = loanAccountRepository;
+        _customerRepository = customerRepository;
+        _shopRepository = shopRepository;
+        _productRepository = productRepository;
+        _unitOfMeasureRepository = unitOfMeasureRepository;
     }
 
     public async Task<Result<LoanAccountDto>> Handle(LoanAccountCreateCommand request, CancellationToken cancellationToken)
     {
         var entity = _mapper.Map<LoanAccount>(request.LoanAccountCreateDto);
+        
+        var customer = await _customerRepository.GetByIdAsync(request.LoanAccountCreateDto.CustomerId);
+        entity.CustomerName = customer?.FirstName;
+        
+        var shop = await _shopRepository.GetByIdAsync(request.LoanAccountCreateDto.ShopId);
+        entity.ShopName = shop?.Name;
+        
+        var product = await _productRepository.GetByIdAsync(request.LoanAccountCreateDto.ProductId);
+        entity.ProductName = product?.Name;
+        
+        var unit = await _unitOfMeasureRepository.GetByIdAsync(request.LoanAccountCreateDto.UnitId);
+        entity.UnitName = unit?.Name;
         
         await _loanAccountRepository.AddAsync(entity);
         await _unitOfWork.SaveChanges(cancellationToken);

--- a/SMIS.Application/Features/LoanAccounts/Commands/LoanAccountUpdateCommand.cs
+++ b/SMIS.Application/Features/LoanAccounts/Commands/LoanAccountUpdateCommand.cs
@@ -3,7 +3,11 @@ using MediatR;
 using SMIS.Application.Common.Response;
 using SMIS.Application.DTO.LoanAccounts;
 using SMIS.Application.Repositories.Base;
+using SMIS.Application.Repositories.Customers;
 using SMIS.Application.Repositories.LoanAccounts;
+using SMIS.Application.Repositories.Products;
+using SMIS.Application.Repositories.Shops;
+using SMIS.Application.Repositories.UnitOfMeasures;
 
 namespace SMIS.Application.Features.LoanAccounts.Commands;
 
@@ -12,14 +16,22 @@ public record LoanAccountUpdateCommand(string Id, LoanAccountCreateDto LoanAccou
 internal sealed class LoanAccountUpdateCommandHandler : IRequestHandler<LoanAccountUpdateCommand, Result<LoanAccountDto>>
 {
     private readonly ILoanAccountRepository _loanAccountRepository;
+    private readonly ICustomerRepository _customerRepository;
+    private readonly IShopRepository _shopRepository;
+    private readonly IProductRepository _productRepository;
+    private readonly IUnitOfMeasureRepository _unitOfMeasureRepository;
     private readonly IUnitOfWork _unitOfWork;
     private readonly IMapper _mapper;
 
-    public LoanAccountUpdateCommandHandler(IUnitOfWork unitOfWork, IMapper mapper, ILoanAccountRepository loanAccountRepository)
+    public LoanAccountUpdateCommandHandler(IUnitOfWork unitOfWork, IMapper mapper, ILoanAccountRepository loanAccountRepository, ICustomerRepository customerRepository, IShopRepository shopRepository, IProductRepository productRepository, IUnitOfMeasureRepository unitOfMeasureRepository)
     {
         _unitOfWork = unitOfWork;
         _mapper = mapper;
         _loanAccountRepository = loanAccountRepository;
+        _customerRepository = customerRepository;
+        _shopRepository = shopRepository;
+        _productRepository = productRepository;
+        _unitOfMeasureRepository = unitOfMeasureRepository;
     }
 
     public async Task<Result<LoanAccountDto>> Handle(LoanAccountUpdateCommand request, CancellationToken cancellationToken)
@@ -39,6 +51,18 @@ internal sealed class LoanAccountUpdateCommandHandler : IRequestHandler<LoanAcco
         entity.SetTotalAmount(request.LoanAccountCreateDto.TotalAmount);
         entity.SetDueDate(request.LoanAccountCreateDto.DueDate);
         entity.SetNotes(request.LoanAccountCreateDto.Notes);
+        
+        var customer = await _customerRepository.GetByIdAsync(request.LoanAccountCreateDto.CustomerId);
+        entity.CustomerName = customer?.FirstName;
+        
+        var shop = await _shopRepository.GetByIdAsync(request.LoanAccountCreateDto.ShopId);
+        entity.ShopName = shop?.Name;
+        
+        var product = await _productRepository.GetByIdAsync(request.LoanAccountCreateDto.ProductId);
+        entity.ProductName = product?.Name;
+        
+        var unit = await _unitOfMeasureRepository.GetByIdAsync(request.LoanAccountCreateDto.UnitId);
+        entity.UnitName = unit?.Name;
         
         await _unitOfWork.SaveChanges(cancellationToken);
 

--- a/SMIS.Domain/Entities/LoanAccount.cs
+++ b/SMIS.Domain/Entities/LoanAccount.cs
@@ -7,11 +7,14 @@ namespace SMIS.Domain.Entities;
 public class LoanAccount : BaseAuditableEntity, IShopEntity
 {
     public string CustomerId { get; private set; } = string.Empty;
+    public string? CustomerName { get; set; }
     public string ShopId { get; private set; } = string.Empty;
+    public string? ShopName { get; set; }
     public string ProductId { get; private set; } = string.Empty;
-   
+    public string? ProductName { get; set; }
     public decimal Quantity { get; private set; }
     public string UnitId { get; private set; } = string.Empty;
+    public string? UnitName { get; set; }
     public decimal PriceAtLoanTime { get; private set; }
     public long TotalAmount { get; private set; }
     public DateTime LoanDate { get; private set; }

--- a/SMIS.Infrastructure/DatabaseSeeders/LoanAccountSeed.cs
+++ b/SMIS.Infrastructure/DatabaseSeeders/LoanAccountSeed.cs
@@ -19,6 +19,12 @@ public static class LoanAccountSeed
         var loanAccount = LoanAccount.Create(customerId, shopId, productId, quantity, unitId, priceAtLoanTime, totalAmount, dueDate, notes);
 
         typeof(LoanAccount).GetProperty(nameof(LoanAccount.Id))!.SetValue(loanAccount, id);
+        
+        loanAccount.CustomerName = customerId == "1" ? "John Doe" : customerId == "2" ? "Jane Smith" : null;
+        loanAccount.ShopName = shopId == "1" ? "Main Wholesale Shop" : shopId == "2" ? "Downtown Retail" : null;
+        loanAccount.ProductName = productId == "1" ? "Coca Cola" : productId == "4" ? "Oreo Biscuit" : productId == "7" ? "Notebook A4" : null;
+        loanAccount.UnitName = unitId == "3" ? "Bottle" : unitId == "1" ? "Piece" : null;
+        
         var loanDateProp = typeof(LoanAccount).GetProperty(nameof(LoanAccount.LoanDate));
         if (loanDateProp != null)
         {

--- a/SMIS.Infrastructure/EntityConfigurations/LoanAccountConfiguration.cs
+++ b/SMIS.Infrastructure/EntityConfigurations/LoanAccountConfiguration.cs
@@ -15,11 +15,20 @@ public class LoanAccountConfiguration : IEntityTypeConfiguration<LoanAccount>
         builder.Property(l => l.CustomerId)
             .IsRequired();
 
+        builder.Property(l => l.CustomerName)
+            .HasMaxLength(200);
+
         builder.Property(l => l.ShopId)
             .IsRequired();
 
+        builder.Property(l => l.ShopName)
+            .HasMaxLength(200);
+
         builder.Property(l => l.ProductId)
             .IsRequired();
+
+        builder.Property(l => l.ProductName)
+            .HasMaxLength(200);
 
         builder.Property(l => l.Quantity)
             .IsRequired()
@@ -27,6 +36,9 @@ public class LoanAccountConfiguration : IEntityTypeConfiguration<LoanAccount>
 
         builder.Property(l => l.UnitId)
             .IsRequired();
+
+        builder.Property(l => l.UnitName)
+            .HasMaxLength(100);
 
         builder.Property(l => l.PriceAtLoanTime)
             .IsRequired()


### PR DESCRIPTION
This PR adds name properties to LoanAccount entity and DTO to store associated entity names.\n\nChanges:\n- Added CustomerName, ShopName, ProductName, and UnitName properties to LoanAccount entity\n- Added corresponding properties to LoanAccountDto\n- Updated LoanAccountCreateCommand and LoanAccountUpdateCommand handlers to populate name properties\n- Added repository dependencies for customer, shop, product, and unit of measure lookups\n- Updated LoanAccountConfiguration to include max length for new properties\n- Updated LoanAccountSeed to populate name properties in seed data