### PR TITLE
fix(Infrastructure): use DateTimeService.UtcNow in all database seeders

### DIFF
--- a/SMIS.Infrastructure.Server/DatabaseSeeders/CategorySeed.cs
+++ b/SMIS.Infrastructure.Server/DatabaseSeeders/CategorySeed.cs
@@ -22,8 +22,8 @@ public static class CategorySeed
     {
         var category = Category.Create(name, shopId, code, description, true);
         category.Id = id;
-        category.CreatedDate = DateTimeService.Now;
-        category.UpdatedDate = DateTimeService.Now;
+        category.CreatedDate = DateTimeService.UtcNow;
+        category.UpdatedDate = DateTimeService.UtcNow;
         category.LastModifiedUtc = DateTimeService.UtcNow;
         return category;
 

--- a/SMIS.Infrastructure.Server/DatabaseSeeders/CustomerSeed.cs
+++ b/SMIS.Infrastructure.Server/DatabaseSeeders/CustomerSeed.cs
@@ -35,8 +35,8 @@ public static class CustomerSeed
         // Set ID and ShopName for seeding
         typeof(Customer).GetProperty(nameof(Customer.Id))!.SetValue(customer, id);
         typeof(Customer).GetProperty(nameof(Customer.ShopName))!.SetValue(customer, GetShopName(shopId));
-        typeof(Customer).GetProperty(nameof(Customer.CreatedDate))!.SetValue(customer, DateTimeService.Now);
-        typeof(Customer).GetProperty(nameof(Customer.UpdatedDate))!.SetValue(customer, DateTimeService.Now);
+        typeof(Customer).GetProperty(nameof(Customer.CreatedDate))!.SetValue(customer, DateTimeService.UtcNow);
+        typeof(Customer).GetProperty(nameof(Customer.UpdatedDate))!.SetValue(customer, DateTimeService.UtcNow);
         typeof(Customer).GetProperty(nameof(Customer.LastModifiedUtc))!.SetValue(customer, DateTimeService.UtcNow);
 
         return customer;

--- a/SMIS.Infrastructure.Server/DatabaseSeeders/LoanAccountSeed.cs
+++ b/SMIS.Infrastructure.Server/DatabaseSeeders/LoanAccountSeed.cs
@@ -8,7 +8,7 @@ public static class LoanAccountSeed
 {
     public static void DataSeed(ModelBuilder modelBuilder)
     {
-        var now = DateTimeService.Now;
+        var now = DateTimeService.UtcNow;
         modelBuilder.Entity<LoanAccount>().HasData(
             // Main Store loans
             CreateLoanAccount("1", "1", "1", "1", 10, "2", 5000, 50000, now.AddDays(-30), now.AddDays(30), "Coca Cola loan for John", true),
@@ -43,8 +43,8 @@ public static class LoanAccountSeed
         {
             loanDateProp.SetValue(loanAccount, loanDate);
         }
-        typeof(LoanAccount).GetProperty(nameof(LoanAccount.CreatedDate))!.SetValue(loanAccount, DateTimeService.Now);
-        typeof(LoanAccount).GetProperty(nameof(LoanAccount.UpdatedDate))!.SetValue(loanAccount, DateTimeService.Now);
+        typeof(LoanAccount).GetProperty(nameof(LoanAccount.CreatedDate))!.SetValue(loanAccount, DateTimeService.UtcNow);
+        typeof(LoanAccount).GetProperty(nameof(LoanAccount.UpdatedDate))!.SetValue(loanAccount, DateTimeService.UtcNow);
         typeof(LoanAccount).GetProperty(nameof(LoanAccount.LastModifiedUtc))!.SetValue(loanAccount, DateTimeService.UtcNow);
         if (!isActive) loanAccount.Deactivate();
 

--- a/SMIS.Infrastructure.Server/DatabaseSeeders/ProductPriceSeed.cs
+++ b/SMIS.Infrastructure.Server/DatabaseSeeders/ProductPriceSeed.cs
@@ -97,8 +97,8 @@ public static class ProductPriceSeed
         if (isActive) productPrice.Activate(); else productPrice.Deactivate();
 
         typeof(ProductPrice).GetProperty(nameof(ProductPrice.Id))!.SetValue(productPrice, id);
-        typeof(ProductPrice).GetProperty(nameof(ProductPrice.CreatedDate))!.SetValue(productPrice, DateTimeService.Now);
-        typeof(ProductPrice).GetProperty(nameof(ProductPrice.UpdatedDate))!.SetValue(productPrice, DateTimeService.Now);
+        typeof(ProductPrice).GetProperty(nameof(ProductPrice.CreatedDate))!.SetValue(productPrice, DateTimeService.UtcNow);
+        typeof(ProductPrice).GetProperty(nameof(ProductPrice.UpdatedDate))!.SetValue(productPrice, DateTimeService.UtcNow);
         typeof(ProductPrice).GetProperty(nameof(ProductPrice.LastModifiedUtc))!.SetValue(productPrice, DateTimeService.UtcNow);
 
         return productPrice;

--- a/SMIS.Infrastructure.Server/DatabaseSeeders/ProductSeed.cs
+++ b/SMIS.Infrastructure.Server/DatabaseSeeders/ProductSeed.cs
@@ -48,8 +48,8 @@ public static class ProductSeed
         typeof(Product).GetProperty(nameof(Product.ShopName))!.SetValue(product, GetShopName(shopId));
         typeof(Product).GetProperty(nameof(Product.BaseUnitName))!.SetValue(product, GetUnitName(baseUnitId));
         typeof(Product).GetProperty(nameof(Product.CategoryName))!.SetValue(product, GetCategoryName(categoryId));
-        typeof(Product).GetProperty(nameof(Product.CreatedDate))!.SetValue(product, DateTimeService.Now);
-        typeof(Product).GetProperty(nameof(Product.UpdatedDate))!.SetValue(product, DateTimeService.Now);
+        typeof(Product).GetProperty(nameof(Product.CreatedDate))!.SetValue(product, DateTimeService.UtcNow);
+        typeof(Product).GetProperty(nameof(Product.UpdatedDate))!.SetValue(product, DateTimeService.UtcNow);
         typeof(Product).GetProperty(nameof(Product.LastModifiedUtc))!.SetValue(product, DateTimeService.UtcNow);
 
         return product;

--- a/SMIS.Infrastructure.Server/DatabaseSeeders/ShopOwnerSeed.cs
+++ b/SMIS.Infrastructure.Server/DatabaseSeeders/ShopOwnerSeed.cs
@@ -25,8 +25,8 @@ public static class ShopOwnerSeed
         typeof(ShopOwner).GetProperty(nameof(ShopOwner.ShopName))!.SetValue(owner, GetShopName(shopId));
         owner.SetNationalIdCardNumber(nationalId);
         if (isActive) owner.Activate(); else owner.Deactivate();
-        typeof(ShopOwner).GetProperty(nameof(ShopOwner.CreatedDate))!.SetValue(owner, DateTimeService.Now);
-        typeof(ShopOwner).GetProperty(nameof(ShopOwner.UpdatedDate))!.SetValue(owner, DateTimeService.Now);
+        typeof(ShopOwner).GetProperty(nameof(ShopOwner.CreatedDate))!.SetValue(owner, DateTimeService.UtcNow);
+        typeof(ShopOwner).GetProperty(nameof(ShopOwner.UpdatedDate))!.SetValue(owner, DateTimeService.UtcNow);
         typeof(ShopOwner).GetProperty(nameof(ShopOwner.LastModifiedUtc))!.SetValue(owner, DateTimeService.UtcNow);
 
         return owner;

--- a/SMIS.Infrastructure.Server/DatabaseSeeders/ShopSeed.cs
+++ b/SMIS.Infrastructure.Server/DatabaseSeeders/ShopSeed.cs
@@ -28,8 +28,8 @@ public static class ShopSeed
         typeof(Shop).GetProperty(nameof(Shop.Id))!.SetValue(shop, id);
         
         if (!isActive) shop.Deactivate();
-        typeof(Shop).GetProperty(nameof(Shop.CreatedDate))!.SetValue(shop, DateTimeService.Now);
-        typeof(Shop).GetProperty(nameof(Shop.UpdatedDate))!.SetValue(shop, DateTimeService.Now);
+        typeof(Shop).GetProperty(nameof(Shop.CreatedDate))!.SetValue(shop, DateTimeService.UtcNow);
+        typeof(Shop).GetProperty(nameof(Shop.UpdatedDate))!.SetValue(shop, DateTimeService.UtcNow);
         typeof(Shop).GetProperty(nameof(Shop.LastModifiedUtc))!.SetValue(shop, DateTimeService.UtcNow);
         
         return shop;

--- a/SMIS.Infrastructure.Server/DatabaseSeeders/StockBatchSeed.cs
+++ b/SMIS.Infrastructure.Server/DatabaseSeeders/StockBatchSeed.cs
@@ -10,7 +10,7 @@ public static class StockBatchSeed
 {
     public static void DataSeed(ModelBuilder modelBuilder)
     {
-        var now = DateTimeService.Now;
+        var now = DateTimeService.UtcNow;
         var stockBatches = new[]
         {
             CreateStockBatch("1", "1", "2", 100m, 40000, now.AddDays(-10), "CC-001", now.AddMonths(6)),
@@ -30,8 +30,8 @@ public static class StockBatchSeed
         typeof(StockBatch).GetProperty(nameof(StockBatch.Id))!.SetValue(batch, id);
         typeof(StockBatch).GetProperty(nameof(StockBatch.ProductName))!.SetValue(batch, GetProductName(productId));
         typeof(StockBatch).GetProperty(nameof(StockBatch.UnitName))!.SetValue(batch, GetUnitName(unitId));
-        typeof(StockBatch).GetProperty(nameof(StockBatch.CreatedDate))!.SetValue(batch, DateTimeService.Now);
-        typeof(StockBatch).GetProperty(nameof(StockBatch.UpdatedDate))!.SetValue(batch, DateTimeService.Now);
+        typeof(StockBatch).GetProperty(nameof(StockBatch.CreatedDate))!.SetValue(batch, DateTimeService.UtcNow);
+        typeof(StockBatch).GetProperty(nameof(StockBatch.UpdatedDate))!.SetValue(batch, DateTimeService.UtcNow);
         typeof(StockBatch).GetProperty(nameof(StockBatch.LastModifiedUtc))!.SetValue(batch, DateTimeService.UtcNow);
         
         return batch;

--- a/SMIS.Infrastructure.Server/DatabaseSeeders/StockTransactionSeed.cs
+++ b/SMIS.Infrastructure.Server/DatabaseSeeders/StockTransactionSeed.cs
@@ -37,8 +37,8 @@ public static class StockTransactionSeed
         typeof(StockTransaction).GetProperty(nameof(StockTransaction.ShopName))!.SetValue(transaction, GetShopName(shopId));
         typeof(StockTransaction).GetProperty(nameof(StockTransaction.ProductName))!.SetValue(transaction, GetProductName(productId));
         typeof(StockTransaction).GetProperty(nameof(StockTransaction.UnitName))!.SetValue(transaction, GetUnitName(unitId));
-        typeof(StockTransaction).GetProperty(nameof(StockTransaction.CreatedDate))!.SetValue(transaction, DateTimeService.Now);
-        typeof(StockTransaction).GetProperty(nameof(StockTransaction.UpdatedDate))!.SetValue(transaction, DateTimeService.Now);
+        typeof(StockTransaction).GetProperty(nameof(StockTransaction.CreatedDate))!.SetValue(transaction, DateTimeService.UtcNow);
+        typeof(StockTransaction).GetProperty(nameof(StockTransaction.UpdatedDate))!.SetValue(transaction, DateTimeService.UtcNow);
         typeof(StockTransaction).GetProperty(nameof(StockTransaction.LastModifiedUtc))!.SetValue(transaction, DateTimeService.UtcNow);
 
         return transaction;


### PR DESCRIPTION
## Summary\n\nReplace `DateTimeService.Now` with `DateTimeService.UtcNow` across all 9 database seeders for consistent UTC timestamps.\n\n## Changes\n\n- Update `CategorySeed`, `CustomerSeed`, `LoanAccountSeed`, `ProductPriceSeed`\n- Update `ProductSeed`, `ShopOwnerSeed`, `ShopSeed`, `StockBatchSeed`, `StockTransactionSeed`\n- Ensures seeded data uses the same UTC time standard as runtime entity creation